### PR TITLE
Add support for rectangular membrane/plate

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(GUI_SOURCE
     audio_gui.cpp
     mesh_gui.cpp
+    mesh_manager.cpp
     circular_mesh_manager.cpp
     rectangular_mesh_manager.cpp
     )

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -2,6 +2,7 @@ set(GUI_SOURCE
     audio_gui.cpp
     mesh_gui.cpp
     circular_mesh_manager.cpp
+    rectangular_mesh_manager.cpp
     )
 
 add_library(mesh2dgui STATIC ${GUI_SOURCE})

--- a/src/gui/circular_mesh_manager.cpp
+++ b/src/gui/circular_mesh_manager.cpp
@@ -7,6 +7,7 @@
 #include "mat2d.h"
 #include "rectilinear_mesh.h"
 #include "rimguide.h"
+#include "rimguide_utils.h"
 #include "trimesh.h"
 #include "wave_math.h"
 
@@ -555,13 +556,13 @@ void CircularMeshManager::render_async(float render_time_seconds, RenderComplete
     mesh->init(mask);
     mesh->init_boundary(info);
 
+    mesh->set_input(input_pos_.x, input_pos_.y);
+    mesh->set_output(output_pos_.x, output_pos_.y);
+
     if (clamp_center_)
     {
         mesh->clamp_center_with_rimguide();
     }
-
-    mesh->set_input(input_pos_.x, input_pos_.y);
-    mesh->set_output(output_pos_.x, output_pos_.y);
 
     if (use_time_varying_allpass_)
     {
@@ -609,134 +610,6 @@ void CircularMeshManager::render_async(float render_time_seconds, RenderComplete
     }
 
     std::thread(&CircularMeshManager::render_async_worker, this, std::move(mesh), cb).detach();
-}
-
-void CircularMeshManager::render_async_worker(std::unique_ptr<Mesh2D>&& mesh, RenderCompleteCallback cb)
-{
-    const size_t out_size = render_time_seconds_ * sample_rate_;
-    std::vector<float> out_buffer(out_size);
-
-    stk::PoleZero dc_blocker;
-    dc_blocker.setBlockZero(dc_blocker_alpha_);
-
-    std::vector<float> impulse;
-    if (excitation_type_ == ExcitationType::DIRAC)
-    {
-        impulse.push_back(1);
-    }
-    else if (excitation_type_ == ExcitationType::RAISE_COSINE)
-    {
-        impulse = raised_cosine(excitation_frequency_, sample_rate_);
-    }
-    else if (excitation_type_ == ExcitationType::FILE)
-    {
-        SF_INFO sf_info{0};
-        SNDFILE* file = sf_open(excitation_filename_.c_str(), SFM_READ, &sf_info);
-        if (!file)
-        {
-            std::cerr << "Failed to open file" << std::endl;
-        }
-        else
-        {
-            impulse.resize(sf_info.frames);
-            sf_readf_float(file, impulse.data(), sf_info.frames);
-            sf_close(file);
-        }
-    }
-
-    ListenerInfo listener_info{};
-    listener_info.position = {-0.4f, 0.f, 0.8f};
-    listener_info.samplerate = mesh->get_samplerate();
-    listener_info.type = listener_type_;
-
-    if (listener_type_ == ListenerType::POINT)
-    {
-        listener_info.position = {mesh_->get_output_pos().x, mesh_->get_output_pos().y, 0.0f};
-    }
-
-    Listener listener;
-    listener.init(*mesh, listener_info);
-    if (listener_type_ == ListenerType::ALL)
-    {
-        listener.set_gain(0.2f);
-    }
-    else if (listener_type_ == ListenerType::BOUNDARY)
-    {
-        // TODO: figure out how to scale this properly
-        listener.set_gain(5.f);
-    }
-    else if (listener_type_ == ListenerType::POINT)
-    {
-        listener.set_gain(10.f);
-    }
-
-    progress_ = 0.f;
-
-    auto start = std::chrono::high_resolution_clock::now();
-
-    for (size_t i = 0; i < out_size - 1; i++)
-    {
-        float input = 0.f;
-        if (i < impulse.size())
-        {
-            input = -impulse[i] * excitation_amplitude_;
-        }
-        mesh->tick(input);
-        out_buffer[i] = listener.tick();
-
-        if (use_dc_blocker_)
-        {
-            out_buffer[i] = dc_blocker.tick(out_buffer[i]);
-        }
-
-        float new_progress = static_cast<float>(i) / static_cast<float>(out_size);
-        if (new_progress - progress_ > 0.01f)
-        {
-            progress_ = new_progress;
-        }
-    }
-
-    auto end = std::chrono::high_resolution_clock::now();
-    render_runtime_ = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
-
-    SF_INFO out_sf_info{0};
-    out_sf_info.channels = 1;
-    out_sf_info.format = SF_FORMAT_WAV | SF_FORMAT_FLOAT;
-    out_sf_info.samplerate = static_cast<int>(sample_rate_);
-    out_sf_info.frames = static_cast<sf_count_t>(out_size);
-
-    SNDFILE* out_file = sf_open("mesh.wav", SFM_WRITE, &out_sf_info);
-    if (!out_file)
-    {
-        std::cerr << "Failed to open output file" << std::endl;
-        return;
-    }
-
-    sf_writef_float(out_file, out_buffer.data(), out_size);
-    sf_write_sync(out_file);
-    sf_close(out_file);
-
-    is_rendering_ = false;
-
-    if (cb)
-    {
-        cb();
-    }
-}
-
-float CircularMeshManager::get_progress() const
-{
-    return progress_;
-}
-
-bool CircularMeshManager::is_rendering() const
-{
-    return is_rendering_;
-}
-
-float CircularMeshManager::get_render_runtime() const
-{
-    return render_runtime_;
 }
 
 void CircularMeshManager::plot_mesh() const

--- a/src/gui/circular_mesh_manager.h
+++ b/src/gui/circular_mesh_manager.h
@@ -53,24 +53,6 @@ class CircularMeshManager : public MeshManager
     void render_async(float render_time_seconds, RenderCompleteCallback cb) override;
 
     /**
-     * @brief Gets the progress of the rendering.
-     * @return Progress as a float.
-     */
-    float get_progress() const override;
-
-    /**
-     * @brief Checks if rendering is in progress.
-     * @return True if rendering, false otherwise.
-     */
-    bool is_rendering() const override;
-
-    /**
-     * @brief Gets the runtime of the render.
-     * @return Render runtime in milliseconds.
-     */
-    float get_render_runtime() const override;
-
-    /**
      * @brief Plots the mesh.
      */
     void plot_mesh() const override;
@@ -95,13 +77,6 @@ class CircularMeshManager : public MeshManager
     void update_mesh_object();
 
     /**
-     * @brief Worker function for asynchronous rendering.
-     * @param mesh Unique pointer to the mesh object.
-     * @param cb Callback function to be called upon render completion.
-     */
-    void render_async_worker(std::unique_ptr<Mesh2D>&& mesh, RenderCompleteCallback cb);
-
-    /**
      * @brief Updates the OpenGL mesh.
      */
     void update_gl_mesh();
@@ -111,12 +86,8 @@ class CircularMeshManager : public MeshManager
     MeshType mesh_type_ = MeshType::TRIANGULAR_MESH; ///< Type of the mesh.
     std::unique_ptr<Mesh2D> mesh_{nullptr};          ///< Pointer to the mesh object.
     Listener listener_;                              ///< Listener for events.
-    std::atomic_bool is_rendering_{false};           ///< Flag indicating if rendering is in progress.
-    std::atomic<float> progress_{0.f};               ///< Progress of the rendering.
-    std::atomic<float> render_runtime_{0.f};         ///< Runtime of the render in milliseconds.
 
     // Model parameters
-    int32_t sample_rate_ = 11025;         ///< Sample rate for the simulation.
     float radius_ = 0.32;                 ///< Radius of the circular mesh.
     float decays_ = 25.f;                 ///< Decay factor for the simulation.
     bool use_custom_cutoff_ = false;      ///< Flag to use custom cutoff frequency.
@@ -126,7 +97,6 @@ class CircularMeshManager : public MeshManager
     int32_t tension_ = 3325.f;            ///< Tension of the mesh.
     float minimum_rimguide_delay_ = 1.5f; ///< Minimum delay for the rim guide.
     bool is_solid_boundary_ = true;       ///< Flag indicating if the boundary is solid.
-    float render_time_seconds_ = 1.f;     ///< Time in seconds for rendering.
     Vec2Df input_pos_ = {0.5f, 0.5f};     ///< Input position on the mesh.
     Vec2Df output_pos_ = {0.5f, 0.5f};    ///< Output position on the mesh.
 
@@ -141,14 +111,6 @@ class CircularMeshManager : public MeshManager
     float friction_delay_ = 0.f;      ///< Friction delay.
     float max_radius_ = 0.f;          ///< Maximum radius of the mesh.
     Vec2Di grid_size_ = {0, 0};       ///< Size of the grid.
-
-    // Excitation parameters
-    ExcitationType excitation_type_ = ExcitationType::RAISE_COSINE; ///< Type of excitation.
-    float excitation_frequency_ = 100.f;                            ///< Frequency of the excitation.
-    float excitation_amplitude_ = 1.f;                              ///< Amplitude of the excitation.
-    std::string excitation_filename_{""};
-
-    ListenerType listener_type_ = ListenerType::ALL; ///< Type of listener.
 
     enum class TimeVaryingAllpassType
     {
@@ -177,9 +139,6 @@ class CircularMeshManager : public MeshManager
 
     bool use_nonlinear_allpass_ = false;             ///< Flag to use nonlinear allpass filter.
     float nonlinear_allpass_coeffs_[2] = {0.f, 0.f}; ///< Coefficients for nonlinear allpass filter.
-
-    bool use_dc_blocker_ = false;     ///< Flag to use DC blocker.
-    float dc_blocker_alpha_ = 0.995f; ///< Alpha value for DC blocker.
 
     bool use_extra_diffusion_filters_ = false;
     size_t diffusion_filter_count_ = 0;

--- a/src/gui/mesh_gui.cpp
+++ b/src/gui/mesh_gui.cpp
@@ -8,6 +8,7 @@
 #include "glm/detail/qualifier.hpp"
 #include "imgui.h"
 #include "implot.h"
+#include "rectangular_mesh_manager.h"
 
 #include <algorithm>
 #include <atomic>
@@ -61,7 +62,7 @@ SpectrogramInfo g_spectrogram_info{
 
 float render_time_sec = 1.f;
 
-std::unique_ptr<CircularMeshManager> g_mesh_manager;
+std::unique_ptr<MeshManager> g_mesh_manager;
 
 const std::vector<const char*> kCircularModes = {"(0,1)", "(1,1)", "(2,1)", "(0,2)", "(3,1)", "(1,2)",
                                                  "(4,1)", "(2,2)", "(0,3)", "(5,1)", "(3,2)", "(6,1)"};
@@ -187,6 +188,22 @@ void init_mesh_gui()
     for (int f = 0; f < g_spectrogram_info.num_freqs; ++f)
     {
         g_fft_frq[f] = f * (float)g_spectrogram_info.samplerate / (float)g_spectrogram_info.fft_size;
+    }
+}
+
+void change_mesh_shape(MeshShape shape)
+{
+    switch (shape)
+    {
+    case MeshShape::Circle:
+        g_mesh_manager = std::make_unique<CircularMeshManager>();
+        break;
+    case MeshShape::Rectangle:
+        g_mesh_manager = std::make_unique<RectangularMeshManager>();
+        break;
+    default:
+        g_mesh_manager = std::make_unique<CircularMeshManager>();
+        break;
     }
 }
 
@@ -510,16 +527,16 @@ void draw_spectrum()
             ImPlot::PopStyleColor();
         }
 
-        if (show_theoretical_modes)
-        {
-            for (size_t i = 0; i < kCircularModes.size(); ++i)
-            {
-                ImPlot::PushStyleColor(ImPlotCol_Line, IM_COL32(75, 35, 0, 255));
-                float freq = kCircularRatios[i] * g_mesh_manager->current_fundamental_frequency();
-                ImPlot::PlotInfLines(std::format("Mode {}", i).c_str(), &freq, 1);
-                ImPlot::PopStyleColor();
-            }
-        }
+        // if (show_theoretical_modes)
+        // {
+        //     for (size_t i = 0; i < kCircularModes.size(); ++i)
+        //     {
+        //         ImPlot::PushStyleColor(ImPlotCol_Line, IM_COL32(75, 35, 0, 255));
+        //         float freq = kCircularRatios[i] * g_mesh_manager->current_fundamental_frequency();
+        //         ImPlot::PlotInfLines(std::format("Mode {}", i).c_str(), &freq, 1);
+        //         ImPlot::PopStyleColor();
+        //     }
+        // }
 
         ImPlot::EndPlot();
     }

--- a/src/gui/mesh_gui.h
+++ b/src/gui/mesh_gui.h
@@ -5,6 +5,12 @@
 
 #include <glm/glm.hpp>
 
+enum class MeshShape : int
+{
+    Circle = 0,
+    Rectangle = 1,
+};
+
 /**
  * @class AudioManager
  * @brief Manages audio playback and processing.
@@ -16,6 +22,12 @@ class AudioManager;
  * @note This function should be called once before any other Mesh GUI functions.
  */
 void init_mesh_gui();
+
+/**
+ * @brief Changes the mesh shape.
+ * @param shape The new mesh shape.
+ */
+void change_mesh_shape(MeshShape shape);
 
 /**
  * @brief Draws the audio player interface.

--- a/src/gui/mesh_manager.cpp
+++ b/src/gui/mesh_manager.cpp
@@ -1,0 +1,137 @@
+#include "mesh_manager.h"
+
+#include <memory>
+
+#include <sndfile.h>
+
+#include "gaussian.h"
+#include "listener.h"
+#include "mesh_2d.h"
+
+float MeshManager::get_progress() const
+{
+    return progress_;
+}
+
+bool MeshManager::is_rendering() const
+{
+    return is_rendering_;
+}
+
+float MeshManager::get_render_runtime() const
+{
+    return render_runtime_;
+}
+
+void MeshManager::render_async_worker(std::unique_ptr<Mesh2D>&& mesh, RenderCompleteCallback cb)
+{
+    const size_t out_size = render_time_seconds_ * sample_rate_;
+    std::vector<float> out_buffer(out_size);
+
+    stk::PoleZero dc_blocker;
+    dc_blocker.setBlockZero(dc_blocker_alpha_);
+
+    std::vector<float> impulse;
+    if (excitation_type_ == ExcitationType::DIRAC)
+    {
+        impulse.push_back(1);
+    }
+    else if (excitation_type_ == ExcitationType::RAISE_COSINE)
+    {
+        impulse = raised_cosine(excitation_frequency_, sample_rate_);
+    }
+    else if (excitation_type_ == ExcitationType::FILE)
+    {
+        SF_INFO sf_info{0};
+        SNDFILE* file = sf_open(excitation_filename_.c_str(), SFM_READ, &sf_info);
+        if (!file)
+        {
+            std::cerr << "Failed to open file" << std::endl;
+        }
+        else
+        {
+            impulse.resize(sf_info.frames);
+            sf_readf_float(file, impulse.data(), sf_info.frames);
+            sf_close(file);
+        }
+    }
+
+    ListenerInfo listener_info{};
+    listener_info.position = {-0.4f, 0.f, 0.8f};
+    listener_info.samplerate = mesh->get_samplerate();
+    listener_info.type = listener_type_;
+
+    if (listener_type_ == ListenerType::POINT)
+    {
+        listener_info.position = {mesh->get_output_pos().x, mesh->get_output_pos().y, 0.0f};
+    }
+
+    Listener listener;
+    listener.init(*mesh, listener_info);
+    if (listener_type_ == ListenerType::ALL)
+    {
+        listener.set_gain(0.2f);
+    }
+    else if (listener_type_ == ListenerType::BOUNDARY)
+    {
+        // TODO: figure out how to scale this properly
+        listener.set_gain(5.f);
+    }
+    else if (listener_type_ == ListenerType::POINT)
+    {
+        listener.set_gain(10.f);
+    }
+
+    progress_ = 0.f;
+
+    auto start = std::chrono::high_resolution_clock::now();
+
+    for (size_t i = 0; i < out_size - 1; i++)
+    {
+        float input = 0.f;
+        if (i < impulse.size())
+        {
+            input = -impulse[i] * excitation_amplitude_;
+        }
+        mesh->tick(input);
+        out_buffer[i] = listener.tick();
+
+        if (use_dc_blocker_)
+        {
+            out_buffer[i] = dc_blocker.tick(out_buffer[i]);
+        }
+
+        float new_progress = static_cast<float>(i) / static_cast<float>(out_size);
+        if (new_progress - progress_ > 0.01f)
+        {
+            progress_ = new_progress;
+        }
+    }
+
+    auto end = std::chrono::high_resolution_clock::now();
+    render_runtime_ = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+
+    SF_INFO out_sf_info{0};
+    out_sf_info.channels = 1;
+    out_sf_info.format = SF_FORMAT_WAV | SF_FORMAT_FLOAT;
+    out_sf_info.samplerate = static_cast<int>(sample_rate_);
+    out_sf_info.frames = static_cast<sf_count_t>(out_size);
+
+    SNDFILE* out_file = sf_open("mesh.wav", SFM_WRITE, &out_sf_info);
+    if (!out_file)
+    {
+        std::cerr << "Failed to open output file" << std::endl;
+        return;
+    }
+
+    sf_writef_float(out_file, out_buffer.data(), out_size);
+    sf_write_sync(out_file);
+    sf_close(out_file);
+
+    is_rendering_ = false;
+
+    if (cb)
+    {
+        cb();
+    }
+}

--- a/src/gui/mesh_manager.h
+++ b/src/gui/mesh_manager.h
@@ -3,6 +3,9 @@
 #include <functional>
 #include <glm/glm.hpp>
 
+#include "listener.h"
+#include "mesh_2d.h"
+
 using RenderCompleteCallback = std::function<void()>;
 
 /**
@@ -34,11 +37,31 @@ class MeshManager
     virtual void draw_experimental_config_menu() = 0;
     virtual void render_async(float render_time_seconds, RenderCompleteCallback cb) = 0;
 
-    virtual float get_progress() const = 0;
-    virtual bool is_rendering() const = 0;
-    virtual float get_render_runtime() const = 0;
+    virtual float get_progress() const;
+    virtual bool is_rendering() const;
+    virtual float get_render_runtime() const;
 
     virtual void plot_mesh() const = 0;
 
     virtual void render_gl_mesh(glm::mat4 mvp) const = 0;
+
+  protected:
+    virtual void render_async_worker(std::unique_ptr<Mesh2D>&& mesh, RenderCompleteCallback cb);
+
+    int32_t sample_rate_ = 11025; ///< Sample rate for the simulation.
+
+    ExcitationType excitation_type_ = ExcitationType::RAISE_COSINE; ///< Type of excitation.
+    float excitation_frequency_ = 100.f;                            ///< Frequency of the excitation.
+    float excitation_amplitude_ = 1.f;                              ///< Amplitude of the excitation.
+    std::string excitation_filename_{""};
+    ListenerType listener_type_ = ListenerType::ALL; ///< Type of listener.
+
+    float render_time_seconds_ = 1.f; ///< Time in seconds for rendering.
+
+    bool use_dc_blocker_ = false;     ///< Flag to use DC blocker.
+    float dc_blocker_alpha_ = 0.995f; ///< Alpha value for DC blocker.
+
+    std::atomic_bool is_rendering_{false};   ///< Flag indicating if rendering is in progress.
+    std::atomic<float> progress_{0.f};       ///< Progress of the rendering.
+    std::atomic<float> render_runtime_{0.f}; ///< Runtime of the render in milliseconds.
 };

--- a/src/gui/mesh_manager.h
+++ b/src/gui/mesh_manager.h
@@ -5,6 +5,25 @@
 
 using RenderCompleteCallback = std::function<void()>;
 
+/**
+ * @brief Enum class for mesh type.
+ */
+enum class MeshType
+{
+    TRIANGULAR_MESH,
+    RECTILINEAR_MESH
+};
+
+/**
+ * @brief Enum class for excitation type.
+ */
+enum class ExcitationType
+{
+    RAISE_COSINE,
+    DIRAC,
+    FILE,
+};
+
 class MeshManager
 {
   public:

--- a/src/gui/rectangular_mesh_manager.cpp
+++ b/src/gui/rectangular_mesh_manager.cpp
@@ -7,6 +7,7 @@
 #include "mat2d.h"
 #include "rectilinear_mesh.h"
 #include "rimguide.h"
+#include "rimguide_utils.h"
 #include "trimesh.h"
 #include "wave_math.h"
 
@@ -41,46 +42,6 @@ float rand_float()
     float rn = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
     rn = 2.f * rn - 1.f;
     return rn;
-}
-
-float distance_between_point_and_line(Vec2Df P1, Vec2Df P2, Vec2Df P0)
-{
-    return std::abs((P2.y - P1.y) * P0.x - (P2.x - P1.x) * P0.y + P2.x * P1.y - P2.y * P1.x) /
-           std::sqrt((P2.y - P1.y) * (P2.y - P1.y) + (P2.x - P1.x) * (P2.x - P1.x));
-}
-
-Vec2Df get_boundary_position_rect(float length, float width, const Vec2Df& junction_pos)
-{
-    std::array<float, 4> distances;
-    // north
-    distances[0] =
-        distance_between_point_and_line({-length / 2.f, width / 2.f}, {length / 2.f, width / 2.f}, junction_pos);
-    // south
-    distances[1] =
-        distance_between_point_and_line({-length / 2.f, -width / 2.f}, {length / 2.f, -width / 2.f}, junction_pos);
-    // east
-    distances[2] =
-        distance_between_point_and_line({length / 2.f, -width / 2.f}, {length / 2.f, width / 2.f}, junction_pos);
-    // west
-    distances[3] =
-        distance_between_point_and_line({-length / 2.f, -width / 2.f}, {-length / 2.f, width / 2.f}, junction_pos);
-
-    float min_dist_idx = std::distance(distances.begin(), std::min_element(distances.begin(), distances.end()));
-
-    switch (static_cast<int>(min_dist_idx))
-    {
-    case 0:
-        return {junction_pos.x, width / 2.f};
-    case 1:
-        return {junction_pos.x, -width / 2.f};
-    case 2:
-        return {length / 2.f, junction_pos.y};
-    case 3:
-        return {-length / 2.f, junction_pos.y};
-    default:
-        return {0, 0};
-    }
-    return {0, 0};
 }
 
 } // namespace
@@ -647,134 +608,6 @@ void RectangularMeshManager::render_async(float render_time_seconds, RenderCompl
     }
 
     std::thread(&RectangularMeshManager::render_async_worker, this, std::move(mesh), cb).detach();
-}
-
-void RectangularMeshManager::render_async_worker(std::unique_ptr<Mesh2D>&& mesh, RenderCompleteCallback cb)
-{
-    const size_t out_size = render_time_seconds_ * sample_rate_;
-    std::vector<float> out_buffer(out_size);
-
-    stk::PoleZero dc_blocker;
-    dc_blocker.setBlockZero(dc_blocker_alpha_);
-
-    std::vector<float> impulse;
-    if (excitation_type_ == ExcitationType::DIRAC)
-    {
-        impulse.push_back(1);
-    }
-    else if (excitation_type_ == ExcitationType::RAISE_COSINE)
-    {
-        impulse = raised_cosine(excitation_frequency_, sample_rate_);
-    }
-    else if (excitation_type_ == ExcitationType::FILE)
-    {
-        SF_INFO sf_info{0};
-        SNDFILE* file = sf_open(excitation_filename_.c_str(), SFM_READ, &sf_info);
-        if (!file)
-        {
-            std::cerr << "Failed to open file" << std::endl;
-        }
-        else
-        {
-            impulse.resize(sf_info.frames);
-            sf_readf_float(file, impulse.data(), sf_info.frames);
-            sf_close(file);
-        }
-    }
-
-    ListenerInfo listener_info{};
-    listener_info.position = {-0.4f, 0.f, 0.8f};
-    listener_info.samplerate = mesh->get_samplerate();
-    listener_info.type = listener_type_;
-
-    if (listener_type_ == ListenerType::POINT)
-    {
-        listener_info.position = {mesh_->get_output_pos().x, mesh_->get_output_pos().y, 0.0f};
-    }
-
-    Listener listener;
-    listener.init(*mesh, listener_info);
-    if (listener_type_ == ListenerType::ALL)
-    {
-        listener.set_gain(0.2f);
-    }
-    else if (listener_type_ == ListenerType::BOUNDARY)
-    {
-        // TODO: figure out how to scale this properly
-        listener.set_gain(5.f);
-    }
-    else if (listener_type_ == ListenerType::POINT)
-    {
-        listener.set_gain(10.f);
-    }
-
-    progress_ = 0.f;
-
-    auto start = std::chrono::high_resolution_clock::now();
-
-    for (size_t i = 0; i < out_size - 1; i++)
-    {
-        float input = 0.f;
-        if (i < impulse.size())
-        {
-            input = -impulse[i] * excitation_amplitude_;
-        }
-        mesh->tick(input);
-        out_buffer[i] = listener.tick();
-
-        if (use_dc_blocker_)
-        {
-            out_buffer[i] = dc_blocker.tick(out_buffer[i]);
-        }
-
-        float new_progress = static_cast<float>(i) / static_cast<float>(out_size);
-        if (new_progress - progress_ > 0.01f)
-        {
-            progress_ = new_progress;
-        }
-    }
-
-    auto end = std::chrono::high_resolution_clock::now();
-    render_runtime_ = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
-
-    SF_INFO out_sf_info{0};
-    out_sf_info.channels = 1;
-    out_sf_info.format = SF_FORMAT_WAV | SF_FORMAT_FLOAT;
-    out_sf_info.samplerate = static_cast<int>(sample_rate_);
-    out_sf_info.frames = static_cast<sf_count_t>(out_size);
-
-    SNDFILE* out_file = sf_open("mesh.wav", SFM_WRITE, &out_sf_info);
-    if (!out_file)
-    {
-        std::cerr << "Failed to open output file" << std::endl;
-        return;
-    }
-
-    sf_writef_float(out_file, out_buffer.data(), out_size);
-    sf_write_sync(out_file);
-    sf_close(out_file);
-
-    is_rendering_ = false;
-
-    if (cb)
-    {
-        cb();
-    }
-}
-
-float RectangularMeshManager::get_progress() const
-{
-    return progress_;
-}
-
-bool RectangularMeshManager::is_rendering() const
-{
-    return is_rendering_;
-}
-
-float RectangularMeshManager::get_render_runtime() const
-{
-    return render_runtime_;
 }
 
 void RectangularMeshManager::plot_mesh() const

--- a/src/gui/rectangular_mesh_manager.h
+++ b/src/gui/rectangular_mesh_manager.h
@@ -13,20 +13,20 @@
 #include <memory>
 
 /**
- * @brief Manages the circular mesh for rendering and simulation.
+ * @brief Manages the rectangular mesh for rendering and simulation.
  */
-class CircularMeshManager : public MeshManager
+class RectangularMeshManager : public MeshManager
 {
   public:
     /**
-     * @brief Constructs a new CircularMeshManager object.
+     * @brief Constructs a new RectangularMeshManager object.
      */
-    CircularMeshManager();
+    RectangularMeshManager();
 
     /**
-     * @brief Destroys the CircularMeshManager object.
+     * @brief Destroys the RectangularMeshManager object.
      */
-    ~CircularMeshManager() override;
+    ~RectangularMeshManager() override;
 
     /**
      * @brief Draws the configuration menu.
@@ -108,20 +108,18 @@ class CircularMeshManager : public MeshManager
 
     RimguideInfo get_rimguide_info() const;
 
-    MeshType mesh_type_ = MeshType::TRIANGULAR_MESH; ///< Type of the mesh.
-    std::unique_ptr<Mesh2D> mesh_{nullptr};          ///< Pointer to the mesh object.
-    Listener listener_;                              ///< Listener for events.
-    std::atomic_bool is_rendering_{false};           ///< Flag indicating if rendering is in progress.
-    std::atomic<float> progress_{0.f};               ///< Progress of the rendering.
-    std::atomic<float> render_runtime_{0.f};         ///< Runtime of the render in milliseconds.
+    MeshType mesh_type_ = MeshType::RECTILINEAR_MESH; ///< Type of the mesh.
+    std::unique_ptr<Mesh2D> mesh_{nullptr};           ///< Pointer to the mesh object.
+    Listener listener_;                               ///< Listener for events.
+    std::atomic_bool is_rendering_{false};            ///< Flag indicating if rendering is in progress.
+    std::atomic<float> progress_{0.f};                ///< Progress of the rendering.
+    std::atomic<float> render_runtime_{0.f};          ///< Runtime of the render in milliseconds.
 
     // Model parameters
     int32_t sample_rate_ = 11025;         ///< Sample rate for the simulation.
-    float radius_ = 0.32;                 ///< Radius of the circular mesh.
-    float decays_ = 25.f;                 ///< Decay factor for the simulation.
-    bool use_custom_cutoff_ = false;      ///< Flag to use custom cutoff frequency.
-    float cutoff_freq_ = 0.f;             ///< Custom cutoff frequency.
-    float cutoff_freq_hz_ = 1000.f;       ///< Cutoff frequency in Hz.
+    float length_ = 0.32;                 ///< Length of the rectangular mesh.
+    float width_ = 0.32;                  ///< Width of the rectangular mesh.
+    float filter_pole_ = 0.02f;           ///< Pole for the filter.
     float density_ = 0.262;               ///< Density of the mesh material.
     int32_t tension_ = 3325.f;            ///< Tension of the mesh.
     float minimum_rimguide_delay_ = 1.5f; ///< Minimum delay for the rim guide.
@@ -139,7 +137,8 @@ class CircularMeshManager : public MeshManager
     float fundamental_frequency_ = 0; ///< Fundamental frequency of the mesh.
     float friction_coeff_ = 0.f;      ///< Friction coefficient.
     float friction_delay_ = 0.f;      ///< Friction delay.
-    float max_radius_ = 0.f;          ///< Maximum radius of the mesh.
+    float max_length_ = 0.0f;         ///< Maximum length of the rectangular mesh.
+    float max_width_ = 0.0f;          ///< Maximum width of the rectangular mesh.
     Vec2Di grid_size_ = {0, 0};       ///< Size of the grid.
 
     // Excitation parameters
@@ -185,6 +184,6 @@ class CircularMeshManager : public MeshManager
     size_t diffusion_filter_count_ = 0;
     std::vector<float> diffusion_filter_coeffs_;
 
-    std::unique_ptr<Line> line_ = nullptr;        ///< Pointer to the line object.
-    std::unique_ptr<Line> circle_line_ = nullptr; ///< Pointer to the circular line object.
+    std::unique_ptr<Line> line_ = nullptr;          ///< Pointer to the line object.
+    std::unique_ptr<Line> boundary_line_ = nullptr; ///< Pointer to the rectangular line object.
 };

--- a/src/gui/rectangular_mesh_manager.h
+++ b/src/gui/rectangular_mesh_manager.h
@@ -53,24 +53,6 @@ class RectangularMeshManager : public MeshManager
     void render_async(float render_time_seconds, RenderCompleteCallback cb) override;
 
     /**
-     * @brief Gets the progress of the rendering.
-     * @return Progress as a float.
-     */
-    float get_progress() const override;
-
-    /**
-     * @brief Checks if rendering is in progress.
-     * @return True if rendering, false otherwise.
-     */
-    bool is_rendering() const override;
-
-    /**
-     * @brief Gets the runtime of the render.
-     * @return Render runtime in milliseconds.
-     */
-    float get_render_runtime() const override;
-
-    /**
      * @brief Plots the mesh.
      */
     void plot_mesh() const override;
@@ -95,13 +77,6 @@ class RectangularMeshManager : public MeshManager
     void update_mesh_object();
 
     /**
-     * @brief Worker function for asynchronous rendering.
-     * @param mesh Unique pointer to the mesh object.
-     * @param cb Callback function to be called upon render completion.
-     */
-    void render_async_worker(std::unique_ptr<Mesh2D>&& mesh, RenderCompleteCallback cb);
-
-    /**
      * @brief Updates the OpenGL mesh.
      */
     void update_gl_mesh();
@@ -110,21 +85,15 @@ class RectangularMeshManager : public MeshManager
 
     MeshType mesh_type_ = MeshType::RECTILINEAR_MESH; ///< Type of the mesh.
     std::unique_ptr<Mesh2D> mesh_{nullptr};           ///< Pointer to the mesh object.
-    Listener listener_;                               ///< Listener for events.
-    std::atomic_bool is_rendering_{false};            ///< Flag indicating if rendering is in progress.
-    std::atomic<float> progress_{0.f};                ///< Progress of the rendering.
-    std::atomic<float> render_runtime_{0.f};          ///< Runtime of the render in milliseconds.
 
     // Model parameters
-    int32_t sample_rate_ = 11025;         ///< Sample rate for the simulation.
-    float length_ = 0.32;                 ///< Length of the rectangular mesh.
-    float width_ = 0.32;                  ///< Width of the rectangular mesh.
-    float filter_pole_ = 0.02f;           ///< Pole for the filter.
+    float length_ = 0.64;                 ///< Length of the rectangular mesh.
+    float width_ = 0.64;                  ///< Width of the rectangular mesh.
+    float filter_pole_ = 0.6f;            ///< Pole for the filter.
     float density_ = 0.262;               ///< Density of the mesh material.
     int32_t tension_ = 3325.f;            ///< Tension of the mesh.
     float minimum_rimguide_delay_ = 1.5f; ///< Minimum delay for the rim guide.
     bool is_solid_boundary_ = true;       ///< Flag indicating if the boundary is solid.
-    float render_time_seconds_ = 1.f;     ///< Time in seconds for rendering.
     Vec2Df input_pos_ = {0.5f, 0.5f};     ///< Input position on the mesh.
     Vec2Df output_pos_ = {0.5f, 0.5f};    ///< Output position on the mesh.
 
@@ -140,14 +109,6 @@ class RectangularMeshManager : public MeshManager
     float max_length_ = 0.0f;         ///< Maximum length of the rectangular mesh.
     float max_width_ = 0.0f;          ///< Maximum width of the rectangular mesh.
     Vec2Di grid_size_ = {0, 0};       ///< Size of the grid.
-
-    // Excitation parameters
-    ExcitationType excitation_type_ = ExcitationType::RAISE_COSINE; ///< Type of excitation.
-    float excitation_frequency_ = 100.f;                            ///< Frequency of the excitation.
-    float excitation_amplitude_ = 1.f;                              ///< Amplitude of the excitation.
-    std::string excitation_filename_{""};
-
-    ListenerType listener_type_ = ListenerType::ALL; ///< Type of listener.
 
     enum class TimeVaryingAllpassType
     {
@@ -176,9 +137,6 @@ class RectangularMeshManager : public MeshManager
 
     bool use_nonlinear_allpass_ = false;             ///< Flag to use nonlinear allpass filter.
     float nonlinear_allpass_coeffs_[2] = {0.f, 0.f}; ///< Coefficients for nonlinear allpass filter.
-
-    bool use_dc_blocker_ = false;     ///< Flag to use DC blocker.
-    float dc_blocker_alpha_ = 0.995f; ///< Alpha value for DC blocker.
 
     bool use_extra_diffusion_filters_ = false;
     size_t diffusion_filter_count_ = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -147,7 +147,9 @@ int main()
     ImVec4 clear_color = ImVec4(0.f, 0.f, 0.f, 1.00f);
 
     std::unique_ptr<AudioManager> audio_manager = AudioManager::CreateAudioManager();
+
     audio_manager->StartAudioStream();
+    MeshShape mesh_shape = MeshShape::Circle;
     init_mesh_gui();
 
     bool show_audio_config_window = false;
@@ -231,6 +233,23 @@ int main()
 
                 ImGui::MenuItem("Audio Menu", nullptr, &show_audio_config_window);
                 ImGui::Separator();
+
+                if (ImGui::BeginMenu("Mesh Shape"))
+                {
+                    static int shape_type = 0;
+                    bool pressed = false;
+                    pressed |= ImGui::RadioButton("Circular", &shape_type, 0);
+                    pressed |= ImGui::RadioButton("Rectangular", &shape_type, 1);
+
+                    mesh_shape = static_cast<MeshShape>(shape_type);
+
+                    if (pressed)
+                    {
+                        change_mesh_shape(mesh_shape);
+                    }
+
+                    ImGui::EndMenu();
+                }
                 ImGui::EndMenu();
             }
             ImGui::EndMenuBar();

--- a/src/mesh_graph/CMakeLists.txt
+++ b/src/mesh_graph/CMakeLists.txt
@@ -4,6 +4,7 @@ set(MESH_SOURCE
     trimesh.cpp
     wave_math.cpp
     rimguide.cpp
+    rimguide_utils.cpp
     mesh_2d.cpp
     listener.cpp
     allpass.cpp

--- a/src/mesh_graph/mesh_2d.cpp
+++ b/src/mesh_graph/mesh_2d.cpp
@@ -62,6 +62,14 @@ void Mesh2D::init_boundary(const RimguideInfo& info)
             rimguides_.push_back(j.get_rimguide());
         }
     }
+
+    // Sort rimguides by their angle.
+    // Not strictly necessary, but helpful when iterating over them.
+    std::sort(rimguides_.begin(), rimguides_.end(), [](const Rimguide* a, const Rimguide* b) {
+        float angle_a = std::atan2(a->get_pos().y, a->get_pos().x);
+        float angle_b = std::atan2(b->get_pos().y, b->get_pos().x);
+        return angle_a < angle_b;
+    });
 }
 
 size_t Mesh2D::get_samplerate() const

--- a/src/mesh_graph/mesh_2d.cpp
+++ b/src/mesh_graph/mesh_2d.cpp
@@ -9,6 +9,14 @@
 
 #define IDX(x, y) ((x) + (y) * lx_)
 
+namespace
+{
+bool is_within_rect(float x, float y, float length, float width)
+{
+    return x >= -length / 2.f && x <= length / 2.f && y >= -width / 2.f && y <= width / 2.f;
+}
+} // namespace
+
 Mesh2D::Mesh2D()
     : input_x(0)
     , input_y(0)
@@ -46,6 +54,22 @@ Mat2D<uint8_t> Mesh2D::get_mask_for_radius(float radius) const
             {
                 mask(x, y) = 0;
             }
+        }
+    }
+    return mask;
+}
+
+Mat2D<uint8_t> Mesh2D::get_mask_for_rect(float length, float width) const
+{
+    Mat2D<uint8_t> mask;
+    mask.allocate(lx_, ly_);
+
+    for (size_t y = 0; y < ly_; ++y)
+    {
+        for (size_t x = 0; x < lx_; ++x)
+        {
+            const auto pos = junctions_(x, y).get_pos();
+            mask(x, y) = is_within_rect(pos.x, pos.y, length, width) ? 1 : 0;
         }
     }
     return mask;

--- a/src/mesh_graph/mesh_2d.h
+++ b/src/mesh_graph/mesh_2d.h
@@ -46,6 +46,8 @@ class Mesh2D
      */
     virtual Mat2D<uint8_t> get_mask_for_radius(float radius) const;
 
+    virtual Mat2D<uint8_t> get_mask_for_rect(float length, float width) const;
+
     /**
      * @brief Initializes the mesh with a given mask.
      * @param mask The mask to initialize the mesh with.

--- a/src/mesh_graph/mesh_graph_test.cpp
+++ b/src/mesh_graph/mesh_graph_test.cpp
@@ -2,6 +2,7 @@
 #include "gaussian.h"
 #include "rectilinear_mesh.h"
 #include "rimguide.h"
+#include "rimguide_utils.h"
 #include "wave_math.h"
 
 #include <array>

--- a/src/mesh_graph/mesh_graph_test.cpp
+++ b/src/mesh_graph/mesh_graph_test.cpp
@@ -56,12 +56,12 @@ std::vector<float> render(float tension, float density, float radius)
     const size_t kGridY = grid_size[1];
 
     RimguideInfo info{};
-    info.radius = kRadius;
     info.friction_coeff = -friction_coeff;
     info.friction_delay = friction_delay;
     info.wave_speed = c;
     info.sample_rate = kSampleRate;
     info.is_solid_boundary = true;
+    info.get_rimguide_pos = std::bind(get_boundary_position, kRadius, std::placeholders::_1);
 
     std::vector<float> out_buffer(kOutputSize, 0.0f);
     out_buffer.reserve(kOutputSize);

--- a/src/mesh_graph/perf_tests.cpp
+++ b/src/mesh_graph/perf_tests.cpp
@@ -51,12 +51,12 @@ TEST_CASE("TriMesh")
     const size_t kGridY = grid_size[1];
 
     RimguideInfo info{};
-    info.radius = kRadius;
     info.friction_coeff = -friction_coeff;
     info.friction_delay = friction_delay;
     info.wave_speed = c;
     info.sample_rate = kSampleRate;
     info.is_solid_boundary = true;
+    info.get_rimguide_pos = std::bind(get_boundary_position, kRadius, std::placeholders::_1);
 
     TriMesh mesh(kGridX, kGridY, sample_distance);
     auto mask = mesh.get_mask_for_radius(max_radius);
@@ -126,12 +126,12 @@ TEST_CASE("Rectangular mesh")
     const size_t kGridY = grid_size[1];
 
     RimguideInfo info{};
-    info.radius = kRadius;
     info.friction_coeff = -friction_coeff;
     info.friction_delay = friction_delay;
     info.wave_speed = c;
     info.sample_rate = kSampleRate;
     info.is_solid_boundary = true;
+    info.get_rimguide_pos = std::bind(get_boundary_position, kRadius, std::placeholders::_1);
 
     RectilinearMesh rect_mesh(kGridX, kGridY, sample_distance);
     auto mask = rect_mesh.get_mask_for_radius(max_radius);
@@ -208,12 +208,12 @@ TEST_CASE("TriMesh single thread- BigO")
         const size_t kGridY = grid_size[1];
 
         RimguideInfo info{};
-        info.radius = radius;
         info.friction_coeff = -friction_coeff;
         info.friction_delay = friction_delay;
         info.wave_speed = c;
         info.sample_rate = kSampleRate;
         info.is_solid_boundary = true;
+        info.get_rimguide_pos = std::bind(get_boundary_position, kRadius, std::placeholders::_1);
 
         TriMesh mesh(kGridX, kGridY, sample_distance);
         auto mask = mesh.get_mask_for_radius(max_radius);
@@ -269,12 +269,12 @@ TEST_CASE("TriMesh multi thread- BigO")
         const size_t kGridY = grid_size[1];
 
         RimguideInfo info{};
-        info.radius = radius;
         info.friction_coeff = -friction_coeff;
         info.friction_delay = friction_delay;
         info.wave_speed = c;
         info.sample_rate = kSampleRate;
         info.is_solid_boundary = true;
+        info.get_rimguide_pos = std::bind(get_boundary_position, kRadius, std::placeholders::_1);
 
         TriMesh mesh(kGridX, kGridY, sample_distance);
         auto mask = mesh.get_mask_for_radius(max_radius);

--- a/src/mesh_graph/perf_tests.cpp
+++ b/src/mesh_graph/perf_tests.cpp
@@ -5,6 +5,7 @@
 #include "nanobench.h"
 #include "rectilinear_mesh.h"
 #include "rimguide.h"
+#include "rimguide_utils.h"
 #include "trimesh.h"
 #include "wave_math.h"
 

--- a/src/mesh_graph/rimguide.cpp
+++ b/src/mesh_graph/rimguide.cpp
@@ -19,14 +19,6 @@ constexpr float kPitchBendScaler = 100.f;
 
 } // namespace
 
-Vec2Df get_boundary_position(float radius, const Vec2Df& junction_pos)
-{
-    float dist_2_center = get_distance({0, 0}, junction_pos);
-    float x_unit = junction_pos.x / dist_2_center;
-    float y_unit = junction_pos.y / dist_2_center;
-    return {x_unit * radius, y_unit * radius};
-}
-
 Rimguide::Rimguide()
     : junction_(nullptr)
     , delay_(0)

--- a/src/mesh_graph/rimguide.cpp
+++ b/src/mesh_graph/rimguide.cpp
@@ -17,20 +17,15 @@ namespace
 
 constexpr float kPitchBendScaler = 100.f;
 
-/// @brief Return the position on the boundary of a circle with the given radius based on the junction position
-/// @param junction_pos Position of the junction
-/// @param radius Radius of the circle
-/// @return Position on the boundary of the circle
-/// @note The position is found by drawing a line from the center of the circle to the junction position
-/// and scaling it to the radius of the circle
-Vec2Df get_boundary_position(const Vec2Df& junction_pos, float radius)
+} // namespace
+
+Vec2Df get_boundary_position(float radius, const Vec2Df& junction_pos)
 {
     float dist_2_center = get_distance({0, 0}, junction_pos);
     float x_unit = junction_pos.x / dist_2_center;
     float y_unit = junction_pos.y / dist_2_center;
     return {x_unit * radius, y_unit * radius};
 }
-} // namespace
 
 Rimguide::Rimguide()
     : junction_(nullptr)
@@ -63,7 +58,7 @@ void Rimguide::init(const RimguideInfo& info, Junction* junction)
 {
     junction_ = junction;
 
-    pos_ = get_boundary_position(junction_->get_pos(), info.radius);
+    pos_ = info.get_rimguide_pos(junction->get_pos());
 
     float distance_2_junction = get_distance(pos_, junction_->get_pos());
     float sample_distance = info.sample_rate / info.wave_speed;

--- a/src/mesh_graph/rimguide.h
+++ b/src/mesh_graph/rimguide.h
@@ -9,6 +9,8 @@
 #include <Noise.h>
 #include <OnePole.h>
 #include <PoleZero.h>
+
+#include <functional>
 #include <memory>
 
 class Junction;
@@ -16,7 +18,6 @@ class Junction;
 /// @brief Configuration parameters for a rim guide waveguide
 struct RimguideInfo
 {
-    float radius;                        ///< Radius of the rim guide
     float friction_coeff;                ///< Friction coefficient for damping
     float friction_delay;                ///< Delay time for friction effects
     float wave_speed;                    ///< Speed of wave propagation
@@ -31,7 +32,16 @@ struct RimguideInfo
     float nonlinear_allpass_coeffs[2];   ///< Coefficients for nonlinear allpass
     bool use_extra_diffusion_filters;    ///< Enable extra diffusion filters
     std::vector<float> diffusion_coeffs; ///< Coefficients for diffusion filters
+    std::function<Vec2Df(Vec2Df)> get_rimguide_pos; ///< Function to get the position of the rimguide
 };
+
+/// @brief Return the position on the boundary of a circle with the given radius based on the junction position
+/// @param junction_pos Position of the junction
+/// @param radius Radius of the circle
+/// @return Position on the boundary of the circle
+/// @note The position is found by drawing a line from the center of the circle to the junction position
+/// and scaling it to the radius of the circle
+Vec2Df get_boundary_position(float radius, const Vec2Df& junction_pos);
 
 /// @brief Implements a waveguide model for rim excitation simulation
 class Rimguide

--- a/src/mesh_graph/rimguide_utils.cpp
+++ b/src/mesh_graph/rimguide_utils.cpp
@@ -1,0 +1,53 @@
+#include "rimguide_utils.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+
+Vec2Df get_boundary_position(float radius, const Vec2Df& junction_pos)
+{
+    float dist_2_center = get_distance({0, 0}, junction_pos);
+    float x_unit = junction_pos.x / dist_2_center;
+    float y_unit = junction_pos.y / dist_2_center;
+    return {x_unit * radius, y_unit * radius};
+}
+
+float distance_between_point_and_line(Vec2Df P1, Vec2Df P2, Vec2Df P0)
+{
+    return std::abs((P2.y - P1.y) * P0.x - (P2.x - P1.x) * P0.y + P2.x * P1.y - P2.y * P1.x) /
+           std::sqrt((P2.y - P1.y) * (P2.y - P1.y) + (P2.x - P1.x) * (P2.x - P1.x));
+}
+
+Vec2Df get_boundary_position_rect(float length, float width, const Vec2Df& junction_pos)
+{
+    std::array<float, 4> distances;
+    // north
+    distances[0] =
+        distance_between_point_and_line({-length / 2.f, width / 2.f}, {length / 2.f, width / 2.f}, junction_pos);
+    // south
+    distances[1] =
+        distance_between_point_and_line({-length / 2.f, -width / 2.f}, {length / 2.f, -width / 2.f}, junction_pos);
+    // east
+    distances[2] =
+        distance_between_point_and_line({length / 2.f, -width / 2.f}, {length / 2.f, width / 2.f}, junction_pos);
+    // west
+    distances[3] =
+        distance_between_point_and_line({-length / 2.f, -width / 2.f}, {-length / 2.f, width / 2.f}, junction_pos);
+
+    float min_dist_idx = std::distance(distances.begin(), std::min_element(distances.begin(), distances.end()));
+
+    switch (static_cast<int>(min_dist_idx))
+    {
+    case 0:
+        return {junction_pos.x, width / 2.f};
+    case 1:
+        return {junction_pos.x, -width / 2.f};
+    case 2:
+        return {length / 2.f, junction_pos.y};
+    case 3:
+        return {-length / 2.f, junction_pos.y};
+    default:
+        return {0, 0};
+    }
+    return {0, 0};
+}

--- a/src/mesh_graph/rimguide_utils.h
+++ b/src/mesh_graph/rimguide_utils.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "vec2d.h"
+
+Vec2Df get_boundary_position(float radius, const Vec2Df& junction_pos);
+float distance_between_point_and_line(Vec2Df P1, Vec2Df P2, Vec2Df P0);
+Vec2Df get_boundary_position_rect(float length, float width, const Vec2Df& junction_pos);

--- a/src/mesh_graph/trimesh_test.cpp
+++ b/src/mesh_graph/trimesh_test.cpp
@@ -54,7 +54,6 @@ int main()
     const size_t kGridY = grid_size[1];
 
     RimguideInfo info{};
-    info.radius = kRadius;
     info.friction_coeff = -friction_coeff;
     info.friction_delay = friction_delay;
     info.wave_speed = c;

--- a/src/mesh_graph/trimesh_test.cpp
+++ b/src/mesh_graph/trimesh_test.cpp
@@ -64,6 +64,7 @@ int main()
     info.use_nonlinear_allpass = false;
     info.nonlinear_allpass_coeffs[0] = 0.5f;
     info.nonlinear_allpass_coeffs[1] = 0.1f;
+    info.get_rimguide_pos = std::bind(get_boundary_position, kRadius, std::placeholders::_1);
 
     TriMesh mesh(kGridX, kGridY, sample_distance);
     auto mask = mesh.get_mask_for_radius(max_radius);

--- a/src/mesh_graph/wave_math.cpp
+++ b/src/mesh_graph/wave_math.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 #include <numbers>
+#include <utility>
 
 float get_wave_speed(float tension, float density)
 {
@@ -21,6 +22,18 @@ float get_max_radius(float radius, float friction_delay, float sample_distance, 
     min_delay = std::max(min_delay, 1.5f);
 
     return radius - ((min_delay + friction_delay) * sample_distance * 0.5f);
+}
+
+std::pair<float, float> get_max_dimensions(float length, float width, float friction_delay, float sample_distance,
+                                           float min_delay)
+{
+    min_delay = std::max(min_delay, 1.5f);
+
+    std::pair<float, float> max_dimensions;
+    std::get<0>(max_dimensions) = length - ((min_delay + friction_delay) * sample_distance);
+    std::get<1>(max_dimensions) = width - ((min_delay + friction_delay) * sample_distance);
+
+    return max_dimensions;
 }
 
 float get_fundamental_frequency(float radius, float wave_speed, float sample_rate)
@@ -52,6 +65,11 @@ float get_friction_coeff(float radius, float wave_speed, float decay_rate, float
 
 float get_friction_delay(float friction_coeff, float fund_freq)
 {
+    if (friction_coeff >= 0)
+    {
+        return 0;
+    }
+
     return (std::atan((-friction_coeff * std::sin(fund_freq)) / (friction_coeff * std::cos(fund_freq) + 1)) /
             fund_freq);
 }
@@ -61,6 +79,16 @@ std::array<size_t, 2> get_grid_size(float radius, float sample_distance, float v
     float radius_sample = radius / sample_distance;
     size_t x = static_cast<size_t>(std::ceil(radius_sample * 2));
     size_t y = static_cast<size_t>(std::ceil(radius_sample * 2 * vertical_scaler));
+
+    return {x, y};
+}
+
+std::array<size_t, 2> get_grid_size_for_rect(float length, float width, float sample_distance, float vertical_scaler)
+{
+    float length_sample = length / sample_distance;
+    float width_sample = width / sample_distance;
+    size_t x = static_cast<size_t>(std::ceil(length_sample));
+    size_t y = static_cast<size_t>(std::ceil(width_sample * vertical_scaler));
 
     return {x, y};
 }

--- a/src/mesh_graph/wave_math.h
+++ b/src/mesh_graph/wave_math.h
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <cstddef>
+#include <utility>
 
 /**
  * Calculates the wave propagation speed in a material
@@ -27,6 +28,9 @@ float get_sample_distance(float wave_speed, float sample_rate);
  * @return Maximum radius
  */
 float get_max_radius(float radius, float friction_delay, float sample_distance, float min_delay = 1.5f);
+
+std::pair<float, float> get_max_dimensions(float length, float width, float friction_delay, float sample_distance,
+                                           float min_delay);
 
 /**
  * Calculates the fundamental frequency of the mesh
@@ -56,3 +60,5 @@ float get_friction_coeff(float radius, float wave_speed, float decay_rate, float
 float get_friction_delay(float friction_coeff, float fund_freq);
 
 std::array<size_t, 2> get_grid_size(float radius, float sample_distance, float vertical_scaler = 1);
+
+std::array<size_t, 2> get_grid_size_for_rect(float length, float width, float sample_distance, float vertical_scaler);


### PR DESCRIPTION
This PR adds support for rectangular plate/membrane. The shape of the membrane can be selected in the 'option' menu.